### PR TITLE
use latest nixpkgs (with rust 1.76) to build fastn

### DIFF
--- a/fastn.nix
+++ b/fastn.nix
@@ -13,8 +13,8 @@ rustPlatform.buildRustPackage {
   nativeBuildInputs = [ pkg-config ];
 
   # TODO:use deno_core. can't do this until we can build rusty_v8 with musl
-  # libc
-  buildFeatures = [ "quickjs" ];
+  # libc or figure out static linking with glibc
+  buildFeatures = [ "quickjs" "fifthtry" ];
 
   buildInputs = lib.optional stdenv.targetPlatform.isWindows [
     windows.mingw_w64_pthreads

--- a/flake.lock
+++ b/flake.lock
@@ -20,18 +20,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1705901790,
-        "narHash": "sha256-gZzL+E91/DJyvF+OxRNbgzAGTLkcm9CxIgFZyeDXCBU=",
-        "owner": "junjihashimoto",
+        "lastModified": 1713442664,
+        "narHash": "sha256-LoExypse3c/uun/39u4bPTN4wejIF7hNsdITZO41qTw=",
+        "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8c2abbaad6456d7a3c9752bfc2caf4d982427100",
+        "rev": "d764f230634fa4f86dc8d01c6af9619c7cc5d225",
         "type": "github"
       },
       "original": {
-        "owner": "junjihashimoto",
-        "ref": "feature/rust-dup",
-        "repo": "nixpkgs",
-        "type": "github"
+        "id": "nixpkgs",
+        "type": "indirect"
       }
     },
     "root": {

--- a/flake.nix
+++ b/flake.nix
@@ -4,7 +4,6 @@
 
     # TODO: use nixpkgs/unstable when this is merged:
     # https://github.com/NixOS/nixpkgs/pull/282798
-    nixpkgs.url = "github:junjihashimoto/nixpkgs/feature/rust-dup";
   };
 
   outputs = { self, flake-utils, nixpkgs }:


### PR DESCRIPTION
using the latest nixpkgs-unstable(d764f23) to make the release build of fastn. This allows us to use latest versions of deadpool and deadpool_postgres that have rust 1.76 as MSRV